### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dashboard_master.yml
+++ b/.github/workflows/dashboard_master.yml
@@ -64,7 +64,7 @@ jobs:
         path: iam-dashboard/dist
 
     - name: Publish to Docker Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: indigoiam/iam-dashboard
         username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore